### PR TITLE
Updated build-tools to 1.1.1, add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What happened (or feature request):
+
+
+## What you expected to happen:
+
+
+## How to reproduce it (as minimally and precisely as possible):
+
+
+## Anything else do we need to know:
+
+
+## Related source links or issues:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## The Problem:
+
+## The Fix:
+
+## The Test:
+
+## Automation Overview:
+<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
+
+## Related Issue Link(s):
+
+## Release/Deployment notes:
+<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
+

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -36,13 +36,14 @@ cd build-tools
 Using this base will allow you to build with standard targets like build, test, container, push, clean:
 
 ```
-make 
+make
 make linux
 make darwin
-make gofmt 
+make gofmt
 make govet
 make govendor
 make golint
+make codecoroner
 make static (gofmt, govet, golint, govendor)
 make test
 make container

--- a/build-tools/build_update.sh
+++ b/build-tools/build_update.sh
@@ -40,7 +40,8 @@ tar -xf $local_file
 rm -rf build-tools/*
 cp -r $internal_name/ build-tools/
 rm -rf $internal_name/
-rm -rf build-tools/tests/ build-tools/circle.yml
+rm -rf build-tools/tests/ build-tools/circle.yml build-tools/.github
+touch build-tools/build-tools-VERSION-$tag.txt
 git add build-tools
 echo "Updated build-tools to $tag
 

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -11,7 +11,7 @@ SHELL := /bin/bash
 
 GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
 
-BUILD_IMAGE ?= drud/golang-build-container:0.1.0
+BUILD_IMAGE ?= drud/golang-build-container:v0.3.0
 
 BUILD_BASE_DIR ?= $$PWD
 
@@ -84,6 +84,52 @@ golint:
 		-w /go/src/$(PKG)                                                  \
 		$(BUILD_IMAGE)                                                     \
 		bash -c 'export OUT=$$(golint $(SRC_AND_UNDER)) && if [ -n "$$OUT" ]; then echo "Golint problems discovered: $$OUT"; exit 1; fi'
+
+errcheck:
+	@echo -n "Checking errcheck: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		errcheck $(SRC_AND_UNDER)
+
+staticcheck:
+	@echo -n "Checking staticcheck: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		staticcheck $(SRC_AND_UNDER)
+
+unused:
+	@echo -n "Checking unused variables and functions: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		unused $(SRC_AND_UNDER)
+
+codecoroner:
+	@echo -n "Checking codecoroner for unused functions: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE) \
+		bash -c 'OUT=$$(codecoroner -tests -ignore vendor funcs $(SRC_AND_UNDER)); if [ -n "$$OUT" ]; then echo "$$OUT"; exit 1; fi'                                             \
+
+
+varcheck:
+	@echo -n "Checking unused globals and struct members: "
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
+		-v $$(pwd)/.go:/go                                                 \
+		-v $$(pwd):/go/src/$(PKG)                                          \
+		-w /go/src/$(PKG)                                                  \
+		$(BUILD_IMAGE)                                                     \
+		varcheck $(SRC_AND_UNDER) && structcheck $(SRC_AND_UNDER)
 
 
 version:

--- a/build-tools/makefile_components/base_build_python-docker.mak
+++ b/build-tools/makefile_components/base_build_python-docker.mak
@@ -9,7 +9,7 @@
 
 SHELL := /bin/bash
 
-BUILD_IMAGE ?= golang:1.7-alpine
+BUILD_IMAGE ?= drud/golang-build-container:v0.2.0
 
 all: VERSION.txt build
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,4 @@ stages:
       # Run the tests
       - type: shell
         command: make test
+


### PR DESCRIPTION
## The Problem:

* Might as well have current build-tools
* Adds github templates from ddev

## The Fix:

Trivial upgrades

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

