### PR TITLE
Add bash to phpmyadmin container

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,5 +1,6 @@
 FROM UPSTREAM_REPO
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl bash
 
 HEALTHCHECK CMD curl --fail http://localhost > /dev/null || exit 1
+


### PR DESCRIPTION
## The Problem:

ddev assumes that bash will be available on all containers. Without this PR `ddev ssh -p dba` will fail because bash is not there.

```
$ ddev ssh -s dba
rpc error: code = 2 desc = oci runtime error: exec failed: container_linux.go:247: starting container process caused "exec: \"bash\": executable file not found in $PATH"

2017/04/23 18:04:25 exit status 126
Failed to run exec command.
```

## The Fix:

Add bash package.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

We could go through the dockerhub push/version bump routine, but I'm not sure it has to be done for this PR.

