### PR TITLE
Fix broken phpmyadmin test by adding curl-dev

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM UPSTREAM_REPO
 
-RUN apk add --no-cache curl bash
+RUN apk add --no-cache curl curl-dev bash vim
 
 HEALTHCHECK CMD curl --fail http://localhost > /dev/null || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,6 @@ include build-tools/makefile_components/base_push.mak
 test: container
 	@docker stop phpmyadmin-test || true
 	@docker rm phpmyadmin-test || true
-	docker run -p 1081:80 -d --name phpmyadmin-test -d `awk '{print $$1}' .docker_image`
+	docker run -p 1081:80 -d --name phpmyadmin-test -d $(DOCKER_REPO):$(VERSION)
 	CONTAINER_NAME=phpmyadmin-test test/containercheck.sh
 	@docker stop phpmyadmin-test && docker rm phpmyadmin-test


### PR DESCRIPTION
## The Problem:

phpmyadmin tests suddenly stopped working both separately and in nightly build. 

## The Fix:

curl was broken in latest Alpine linux, and as suggested in https://stackoverflow.com/a/41651363/215713 I added curl-dev to the packages and curl started working. Curl failing made the docker HEALTHCHECK never succeed. 

While there I simplified the makefile just slightly with a technique I've used more recently.

## The Test:

Check it out and run `make test`

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:

* New release will be required.
* ddev can be updated with the new release, probably best that way.
