### PR TITLE
Update upstream phpmyadmin image, remove curl-dev

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,5 +2,5 @@ FROM phpmyadmin/phpmyadmin:4.7.4-1
 
 RUN apk add --no-cache curl bash vim
 
-HEALTHCHECK CMD curl --fail http://localhost > /dev/null || exit 1
+HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://localhost || exit 1
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,6 @@
-FROM UPSTREAM_REPO
+FROM phpmyadmin/phpmyadmin:4.7.4-1
 
-RUN apk add --no-cache curl curl-dev bash vim
+RUN apk add --no-cache curl bash vim
 
 HEALTHCHECK CMD curl --fail http://localhost > /dev/null || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,6 @@
 # Docker repo for a push
 DOCKER_REPO ?= drud/phpmyadmin
 
-# Upstream repo used in the Dockerfile
-PMA_VERSION_TAG ?= 4.7.0-2
-UPSTREAM_REPO ?= phpmyadmin/phpmyadmin:$(PMA_VERSION_TAG)
-
 # Top-level directories to build
 # SRC_DIRS := files drudapi secrets utils
 


### PR DESCRIPTION
## The Problem:

In https://github.com/drud/docker.phpmyadmin/pull/4 we ran into a problem with curl not working in the upstream phpmyadmin container, and we followed available advice and added the curl-dev package.

That upstream problem seems now to be resolved.

## The Fix:

* Use current upstream phpmyadmin/phpmyadmin
* The image and tag are moved into the Dockerfile
* curl-dev no longer needs to be installed.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

