### PR TITLE
Add curl-dev back into phpmyadmin, alpine curl seems to be broken again

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,6 @@
 FROM phpmyadmin/phpmyadmin:4.7.4-1
 
-RUN apk add --no-cache curl bash vim
+RUN apk add --no-cache curl curl-dev bash vim
 
 HEALTHCHECK --interval=5s --retries=5 CMD curl --fail http://localhost || exit 1
 

--- a/test/containercheck.sh
+++ b/test/containercheck.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-while true;
+for i in {1..10}
 do
     status="$(docker ps --format "{{.Status}}" --filter "name=$CONTAINER_NAME" | sed  's/.*(\(.*\)).*/\1/')"
     if [[ "$status" == "healthy" ]]
     then
-        break
+        exit 0
     fi
     sleep 2
 done
-exit 0
+exit 2


### PR DESCRIPTION
## The Problem:

The ddev nightly build broke again due to a new problem in alpine.  `make test` on docker.phpmyadmin hung.  When execed into the container, this was the symptom:

```
bash-4.3# curl localhost
Error relocating /usr/bin/curl: curl_mime_type: symbol not found
Error relocating /usr/bin/curl: curl_mime_data: symbol not found
Error relocating /usr/bin/curl: curl_mime_data_cb: symbol not found
Error relocating /usr/bin/curl: curl_mime_name: symbol not found
Error relocating /usr/bin/curl: curl_mime_encoder: symbol not found
Error relocating /usr/bin/curl: curl_mime_headers: symbol not found
Error relocating /usr/bin/curl: curl_mime_init: symbol not found
Error relocating /usr/bin/curl: curl_mime_filedata: symbol not found
Error relocating /usr/bin/curl: curl_mime_free: symbol not found
Error relocating /usr/bin/curl: curl_mime_filename: symbol not found
Error relocating /usr/bin/curl: curl_mime_subparts: symbol not found
Error relocating /usr/bin/curl: curl_mime_addpart: symbol not found
```

## The Fix:

* Add curl-dev back in seems to solve the problem.  
* Fix the test (containercheck.sh) so it doesn't wait forever. It now tries for 20 seconds before giving up.

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

